### PR TITLE
Entrega 17may

### DIFF
--- a/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
@@ -1,7 +1,7 @@
 package ayds.lisboa.songinfo.home.controller
 
 import ayds.lisboa.songinfo.home.model.HomeModel
-import ayds.lisboa.songinfo.home.model.entities.Song
+import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
 import ayds.lisboa.songinfo.home.view.HomeUiEvent
 import ayds.lisboa.songinfo.home.view.HomeUiState
 import ayds.lisboa.songinfo.home.view.HomeView
@@ -43,7 +43,7 @@ class HomeControllerTest {
     @Test
     fun `on more details event should navigate to more details`() {
         every { homeView.uiState } returns HomeUiState(songId = "id")
-        val song: Song = mockk { every { artistName } returns "artist" }
+        val song: SpotifySong = mockk { every { artistName } returns "artist" }
         every { homeModel.getSongById("id") } returns song
 
         onActionSubject.notify(HomeUiEvent.MoreDetails)

--- a/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
@@ -1,7 +1,8 @@
 package ayds.lisboa.songinfo.home.model.repository
 
-import ayds.lisboa.songinfo.home.model.entities.SpotifySong
-import ayds.lisboa.songinfo.home.model.entities.EmptySong
+import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.Song.EmptySong
+import ayds.lisboa.songinfo.home.model.entities.Song
 import ayds.lisboa.songinfo.home.model.repository.external.spotify.SpotifyTrackService
 import ayds.lisboa.songinfo.home.model.repository.local.spotify.SpotifyLocalStorage
 import io.mockk.every
@@ -41,7 +42,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by term should return song and mark it as local`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "datePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns song
 
         val result = songRepository.getSongByTerm("term")
@@ -52,7 +53,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given non existing song by term should get the song and store it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "datePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns null
@@ -66,7 +67,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by different term should get the song and update it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "datePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns song

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -1,14 +1,17 @@
 package ayds.lisboa.songinfo.home.view
 
+import DateConverterFactory
+import DateConverterFactoryImpl
 import ayds.lisboa.songinfo.home.model.entities.Song
-import ayds.lisboa.songinfo.home.model.entities.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl() }
+    private val dateConverter: DateConverterFactory = DateConverterFactoryImpl()
+    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateConverter) }
 
     @Test
     fun `given a local song it should return the description`() {
@@ -18,6 +21,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
+            "year",
             "url",
             "url",
             true,
@@ -29,7 +33,7 @@ class SongDescriptionHelperTest {
             "Song: Plush [*]\n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Year: 1992"
+                "Date: 1992 (leap year)"
 
         assertEquals(expected, result)
     }
@@ -42,6 +46,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
+            "year",
             "url",
             "url",
             false,
@@ -53,7 +58,7 @@ class SongDescriptionHelperTest {
             "Song: Plush \n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Year: 1992"
+                "Date: 1992 (leap year)"
 
         assertEquals(expected, result)
     }

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -1,6 +1,6 @@
 package ayds.lisboa.songinfo.home.view
 
-import ConverterYearImpl
+import Converter
 import DateConverterFactory
 import ayds.lisboa.songinfo.home.model.entities.Song
 import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
@@ -11,14 +11,14 @@ import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val dateConverter: DateConverterFactory = mockk(relaxUnitFun = true)
-    private val dateConverterYearImpl : ConverterYearImpl = mockk()
-    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateConverter) }
+    private val dateConverterFactory: DateConverterFactory = mockk(relaxUnitFun = true)
+    private val dateConverter: Converter = mockk()
+    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateConverterFactory) }
 
     @Test
     fun `given a local song it should return the description`() {
-        every {dateConverter.create("year")} returns dateConverterYearImpl
-        every{ dateConverterYearImpl.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
+        every {dateConverterFactory.create("year")} returns dateConverter
+        every{ dateConverter.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
 
         val song: Song = SpotifySong(
             "id",
@@ -45,8 +45,8 @@ class SongDescriptionHelperTest {
 
     @Test
     fun `given a non local song it should return the description`() {
-        every {dateConverter.create("year")} returns dateConverterYearImpl
-        every{ dateConverterYearImpl.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
+        every {dateConverterFactory.create("year")} returns dateConverter
+        every{ dateConverter.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
 
         val song: Song = SpotifySong(
             "id",

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -12,11 +12,14 @@ import org.junit.Test
 class SongDescriptionHelperTest {
 
     private val dateConverter: DateConverterFactory = mockk(relaxUnitFun = true)
+    private val dateConverterYearImpl : ConverterYearImpl = mockk()
     private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateConverter) }
 
     @Test
     fun `given a local song it should return the description`() {
-        every {dateConverter.create("year")} returns ConverterYearImpl()
+        every {dateConverter.create("year")} returns dateConverterYearImpl
+        every{ dateConverterYearImpl.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
+
         val song: Song = SpotifySong(
             "id",
             "Plush",
@@ -42,7 +45,9 @@ class SongDescriptionHelperTest {
 
     @Test
     fun `given a non local song it should return the description`() {
-        every {dateConverter.create("year")} returns ConverterYearImpl()
+        every {dateConverter.create("year")} returns dateConverterYearImpl
+        every{ dateConverterYearImpl.getReleaseDate("1992-01-01")} returns "1992 (leap year)"
+
         val song: Song = SpotifySong(
             "id",
             "Plush",

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -1,20 +1,22 @@
 package ayds.lisboa.songinfo.home.view
 
+import ConverterYearImpl
 import DateConverterFactory
-import DateConverterFactoryImpl
 import ayds.lisboa.songinfo.home.model.entities.Song
 import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
 import io.mockk.mockk
+import io.mockk.every
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val dateConverter: DateConverterFactory = DateConverterFactoryImpl()
+    private val dateConverter: DateConverterFactory = mockk(relaxUnitFun = true)
     private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateConverter) }
 
     @Test
     fun `given a local song it should return the description`() {
+        every {dateConverter.create("year")} returns ConverterYearImpl()
         val song: Song = SpotifySong(
             "id",
             "Plush",
@@ -40,6 +42,7 @@ class SongDescriptionHelperTest {
 
     @Test
     fun `given a non local song it should return the description`() {
+        every {dateConverter.create("year")} returns ConverterYearImpl()
         val song: Song = SpotifySong(
             "id",
             "Plush",

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistRepositoryTest.kt
@@ -1,11 +1,13 @@
-package ayds.lisboa.songinfo.moredetails.domain.repository
+package ayds.lisboa.songinfo.moredetails.data
 
 import ayds.lisboa.songinfo.moredetails.data.ArtistRepositoryImpl
 import ayds.lisboa.songinfo.moredetails.data.external.ArtistService
 import ayds.lisboa.songinfo.moredetails.data.internal.ArtistLocalStorage
 import ayds.lisboa.songinfo.moredetails.domain.entities.Artist
+import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistRepository
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import org.junit.Assert
 import org.junit.Test
@@ -43,6 +45,7 @@ class ArtistRepositoryTest {
         val result = artistRepository.getArtist("name")
 
         Assert.assertEquals(artist, result)
+        Assert.assertTrue(artist.isLocallyStored)
     }
 
 
@@ -61,13 +64,21 @@ class ArtistRepositoryTest {
 
     @Test
     fun `given non existing artist in local storage but existing in external service by name should return artist`() {
-        val artist: Artist.LastFMArtist = mockk()
+        val artist = Artist.LastFMArtist(
+            "name",
+            "info",
+            "url",
+            1,
+            false
+        )
         every { artistLocalStorage.getArtist("name") } returns null
         every { artistService.getArtist("name") } returns artist
 
         val result = artistRepository.getArtist("name")
 
         Assert.assertEquals(artist, result)
+        Assert.assertFalse(artist.isLocallyStored)
+        verify { artistLocalStorage.saveArtist(artist) }
     }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
@@ -1,4 +1,51 @@
 package ayds.lisboa.songinfo.moredetails.domain.repository
 
+import ayds.lisboa.songinfo.moredetails.data.ArtistRepositoryImpl
+import ayds.lisboa.songinfo.moredetails.data.external.ArtistService
+import ayds.lisboa.songinfo.moredetails.data.internal.ArtistLocalStorage
+import ayds.lisboa.songinfo.moredetails.domain.entities.Artist
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert
+import org.junit.Test
+import java.lang.Exception
+
 class ArtistRepositoryTest {
+    private val artistLocalStorage: ArtistLocalStorage = mockk(relaxUnitFun = true)
+    private val artistService: ArtistService = mockk(relaxUnitFun = true)
+
+    private val artistRepository: ArtistRepository by lazy {
+        ArtistRepositoryImpl(artistLocalStorage, artistService)
+    }
+
+    @Test
+    fun `given non existing artist by name should return empty artist`() {
+        every { artistLocalStorage.getArtist("name") } returns null
+
+        val result = artistRepository.getArtist("name")
+
+        assertEquals(Artist.EmptyArtist, result)
+    }
+
+    @Test
+    fun `given existing artist by name should return artist`() {
+        val artist: Artist.LastFMArtist = mockk()
+        every { artistLocalStorage.getArtist("name") } returns artist
+
+        val result = artistRepository.getArtist("id")
+
+        Assert.assertEquals(artist, result)
+    }
+
+    @Test
+    fun `given service exception should return empty artist`() {
+        every { artistLocalStorage.getArtist("name") } returns null
+        every { artistService.getArtist("name") } throws mockk<Exception>()
+
+        val result = artistRepository.getArtist("name")
+
+        Assert.assertEquals(Artist.EmptyArtist, result)
+    }
+
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
@@ -1,0 +1,4 @@
+package ayds.lisboa.songinfo.moredetails.domain.repository
+
+class ArtistRepositoryTest {
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/domain/repository/ArtistRepositoryTest.kt
@@ -9,7 +9,7 @@ import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import org.junit.Assert
 import org.junit.Test
-import java.lang.Exception
+import java.io.IOException
 
 class ArtistRepositoryTest {
     private val artistLocalStorage: ArtistLocalStorage = mockk(relaxUnitFun = true)
@@ -20,8 +20,9 @@ class ArtistRepositoryTest {
     }
 
     @Test
-    fun `given non existing artist by name should return empty artist`() {
+    fun `given non existing artist in local storage and external service by name should return empty artist`() {
         every { artistLocalStorage.getArtist("name") } returns null
+        every { artistService.getArtist("name") } returns null
 
         val result = artistRepository.getArtist("name")
 
@@ -30,22 +31,43 @@ class ArtistRepositoryTest {
 
     @Test
     fun `given existing artist by name should return artist`() {
-        val artist: Artist.LastFMArtist = mockk()
+        val artist = Artist.LastFMArtist(
+            "name",
+            "info",
+            "url",
+            1,
+            false
+        )
         every { artistLocalStorage.getArtist("name") } returns artist
 
-        val result = artistRepository.getArtist("id")
+        val result = artistRepository.getArtist("name")
 
         Assert.assertEquals(artist, result)
     }
 
+
+
     @Test
     fun `given service exception should return empty artist`() {
         every { artistLocalStorage.getArtist("name") } returns null
-        every { artistService.getArtist("name") } throws mockk<Exception>()
+        every { artistService.getArtist("name") } throws IOException()
 
         val result = artistRepository.getArtist("name")
 
         Assert.assertEquals(Artist.EmptyArtist, result)
+    }
+
+
+
+    @Test
+    fun `given non existing artist in local storage but existing in external service by name should return artist`() {
+        val artist: Artist.LastFMArtist = mockk()
+        every { artistLocalStorage.getArtist("name") } returns null
+        every { artistService.getArtist("name") } returns artist
+
+        val result = artistRepository.getArtist("name")
+
+        Assert.assertEquals(artist, result)
     }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/ArtistInfoResolverTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/ArtistInfoResolverTest.kt
@@ -1,14 +1,9 @@
 package ayds.lisboa.songinfo.moredetails.presenter
 
-import ayds.lisboa.songinfo.moredetails.domain.entities.Artist
 import ayds.lisboa.songinfo.moredetails.domain.entities.Artist.LastFMArtist
 import ayds.lisboa.songinfo.moredetails.domain.entities.Artist.EmptyArtist
 import ayds.lisboa.songinfo.moredetails.presentation.ArtistInfoResolver
 import ayds.lisboa.songinfo.moredetails.presentation.ArtistInfoResolverImpl
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -23,97 +18,78 @@ class ArtistInfoResolverTest {
         artistInfoResolver = ArtistInfoResolverImpl()
     }
     @Test
-    fun `given artist info and name and artist is LastFMArtist and info isLocallyStored, when getFormattedInfo is called, then returns formatted info in html`() {
-        // Arrange
+    fun `getFormattedInfo with LastFM artist and locally stored info returns formatted HTML`() {
+
         val artistInfo = LastFMArtist("Test artist", "Test bio","Test url",1,true)
         val artistName = "Test artist"
 
-        // Act
         val result = artistInfoResolver.getFormattedInfo(artistInfo, artistName)
 
-        // Assert
+
         val expected =  "<html><div width=400><font face=\"arial\">[*]Test bio</font></div></html>"
         assertEquals(expected, result)
     }
 
     @Test
-    fun `given artist info and name and artist is LastFMArtist and info not isLocallyStored, when getFormattedInfo is called, then returns formatted info in html`() {
-        // Arrange
+    fun `getFormattedInfo with LastFM artist, not locally stored info returns formatted HTML`() {
         val artistInfo = LastFMArtist("Test artist", "Test bio","Test url",1,false)
         val artistName = "Test artist"
 
-        // Act
         val result = artistInfoResolver.getFormattedInfo(artistInfo, artistName)
 
-        // Assert
         val expected =  "<html><div width=400><font face=\"arial\">Test bio</font></div></html>"
         assertEquals(expected, result)
     }
 
     @Test
-    fun `given artist info and name and artist is emptyArtist, when getFormattedInfo is called, then returns no results`() {
-        // Arrange
+    fun `getFormattedInfo with empty artist returns no results`() {
         val artistInfo = EmptyArtist
         val artistName = "Test empty artist"
 
-        // Act
         val result = artistInfoResolver.getFormattedInfo(artistInfo, artistName)
 
-        // Assert
         val expected = "<html><div width=400><font face=\"arial\">No results</font></div></html>"
         assertEquals(expected, result)
     }
 
     @Test
-    fun `given artist info and name and artist is LastFMArtist and info not isLocallyStored and info is empty, when getFormattedInfo is called, then returns formatted info in html`() {
-        // Arrange
+    fun `getFormattedInfo with LastFM artist, not locally stored info, and empty info returns formatted HTML`() {
         val artistInfo = LastFMArtist("Test artist", "","Test url",1,false)
         val artistName = "Test artist"
 
-        // Act
         val result = artistInfoResolver.getFormattedInfo(artistInfo, artistName)
 
-        // Assert
         val expected =  "<html><div width=400><font face=\"arial\">No results</font></div></html>"
         assertEquals(expected, result)
     }
 
     @Test
-    fun `given artist info and name and artist is LastFMArtist and info isLocallyStored and info is empty, when getFormattedInfo is called, then returns formatted info in html`() {
-        // Arrange
+    fun `getFormattedInfo with LastFM artist, info isLocallyStored and info is empty, returns formatted info in html`() {
         val artistInfo = LastFMArtist("Test artist", "","Test url",1,true)
         val artistName = "Test artist"
 
-        // Act
         val result = artistInfoResolver.getFormattedInfo(artistInfo, artistName)
 
-        // Assert
         val expected =  "<html><div width=400><font face=\"arial\">[*]</font></div></html>"
         assertEquals(expected, result)
     }
 
     @Test
     fun `given artist info and artist is EmptyArtist, when getUrl is called, then returns no results`() {
-        // Arrange
         val artistInfo = EmptyArtist
 
-        // Act
         val result = artistInfoResolver.getUrl(artistInfo)
 
-        //Assert
         val expected = "URL NOT FOUND"
         assertEquals(expected, result)
     }
 
     @Test
     fun `given artist info and artist is LastFMArtist, when getUrl is called, then returns url`() {
-        // Arrange
         val artistInfo = LastFMArtist("Test artist", "Test info","https://www.google.com.ar",1,true)
 
-        // Act
         val result = artistInfoResolver.getUrl(artistInfo)
 
-        //Assert
         val expected = "https://www.google.com.ar"
         assertEquals(expected, result)
     }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/ArtistInfoResolverTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/ArtistInfoResolverTest.kt
@@ -1,0 +1,4 @@
+package ayds.lisboa.songinfo.moredetails.presenter
+
+class ArtistInfoResolverTest {
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
@@ -1,0 +1,4 @@
+package ayds.lisboa.songinfo.moredetails.presenter
+
+class OtherInfoPresenterTest {
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
@@ -1,13 +1,11 @@
 package ayds.lisboa.songinfo.moredetails.presenter
 
-import ayds.lisboa.songinfo.home.view.HomeUiEvent
-import ayds.lisboa.songinfo.home.view.HomeUiState
+import ayds.lisboa.songinfo.moredetails.domain.entities.Artist
 import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistRepository
 import ayds.lisboa.songinfo.moredetails.presentation.*
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Before
 import org.junit.Test
 
 class OtherInfoPresenterTest {
@@ -19,29 +17,26 @@ class OtherInfoPresenterTest {
         OtherInfoPresenterImpl(artistInfoRepository, artistInfoResolver)
     }
 
-    @Before
-    fun setUp() {
-        //otherInfoPresenter.uiEventObservable
-    }
-
     @Test
     fun `should notify uistate on action search event`(){
-        // Arrange
         val artistName = "artist"
         val artistInfo: Artist = mockk()
         val info = "formatted info"
         val url = "https://google.com.ar"
-        val otherInfoUiState = OtherInfoUiState(info, url)
 
         every { artistInfoRepository.getArtist(artistName) } returns artistInfo
         every { artistInfoResolver.getFormattedInfo(artistInfo, artistName) } returns info
         every { artistInfoResolver.getUrl(artistInfo) } returns url
 
-        // Act
+        val otherInfoUiStateTester: (OtherInfoUiState) -> Unit = mockk(relaxed = true)
+        otherInfoPresenter.uiEventObservable.subscribe{
+            otherInfoUiStateTester(it)
+        }
+
         otherInfoPresenter.actionSearch(artistName)
 
-        // Assert
-        verify { otherInfoPresenter.notifyState(otherInfoUiState) }
+        val otherInfoUiStateExpected = OtherInfoUiState(info, url)
+        verify { otherInfoUiStateTester(otherInfoUiStateExpected) }
     }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presenter/OtherInfoPresenterTest.kt
@@ -1,4 +1,47 @@
 package ayds.lisboa.songinfo.moredetails.presenter
 
+import ayds.lisboa.songinfo.home.view.HomeUiEvent
+import ayds.lisboa.songinfo.home.view.HomeUiState
+import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistRepository
+import ayds.lisboa.songinfo.moredetails.presentation.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
 class OtherInfoPresenterTest {
+
+    private val artistInfoRepository: ArtistRepository = mockk(relaxUnitFun = true)
+    private val artistInfoResolver: ArtistInfoResolver = mockk(relaxUnitFun = true)
+
+    private val otherInfoPresenter by lazy {
+        OtherInfoPresenterImpl(artistInfoRepository, artistInfoResolver)
+    }
+
+    @Before
+    fun setUp() {
+        //otherInfoPresenter.uiEventObservable
+    }
+
+    @Test
+    fun `should notify uistate on action search event`(){
+        // Arrange
+        val artistName = "artist"
+        val artistInfo: Artist = mockk()
+        val info = "formatted info"
+        val url = "https://google.com.ar"
+        val otherInfoUiState = OtherInfoUiState(info, url)
+
+        every { artistInfoRepository.getArtist(artistName) } returns artistInfo
+        every { artistInfoResolver.getFormattedInfo(artistInfo, artistName) } returns info
+        every { artistInfoResolver.getUrl(artistInfo) } returns url
+
+        // Act
+        otherInfoPresenter.actionSearch(artistName)
+
+        // Assert
+        verify { otherInfoPresenter.notifyState(otherInfoUiState) }
+    }
+
 }


### PR DESCRIPTION
**_Unit Testing_**

Analizamos los tests unitarios del paquete home y realizamos las modificaciones necesarios para que todos compilen correctamente. 
Además implementamos test unitarios del paquete moredetails siguiendo la misma estrategia utilizada en el paquete home.
Para ello creamos un paquete nuevo llamado moredetails dentro de la carpeta test.
Allí dentro colocamos dos nuevos paquetes:
**data**: se verifica el repository, para ello se crea el test ArtistRepositoryTest.
**presenter**: se verifica el presenter y el helper/resolver de presentation, para ello se crean los tests OtherInfoPresenterTest y ArtistInfoResolverTest respectivamente.
